### PR TITLE
Release v1.0.1

### DIFF
--- a/data/justsap/powers/bush.json
+++ b/data/justsap/powers/bush.json
@@ -98,5 +98,5 @@
       "bar_index": 0
   },
     "name": "Grounded Roots",
-    "description": "You sink your tree roots into the ground and create a bush-like shield, but it takes away 5 xp levels."
+    "description": "You sink your tree roots into the ground and create a bush-like shield, but it takes away 4 EXP levels."
 }

--- a/data/justsap/powers/bush.json
+++ b/data/justsap/powers/bush.json
@@ -2,7 +2,7 @@
     "condition": {
         "type": "origins:xp_levels",
         "comparison": ">=",
-        "compare_to": 2
+        "compare_to": 4
 	},
 
     "type": "origins:active_self",
@@ -38,7 +38,7 @@
             },
             {
                 "type": "origins:add_xp",
-                "levels": -2
+                "levels": -4
             },
             {
                 "type": "origins:apply_effect",

--- a/data/justsap/powers/regenfield.json
+++ b/data/justsap/powers/regenfield.json
@@ -197,7 +197,7 @@
         }
     },
     "name": "Share Nutrients",
-    "description": "If in a 4 block radius with another player, you can create a health regeneration field that heals anyone in it.",
+    "description": "If in a 4 block radius with another player, you can create a field that heals anyone in it, but it takes away 2 EXP levels.",
     "badges": [
         {
             "type": "origins:keybind",

--- a/data/justsap/powers/regenfield.json
+++ b/data/justsap/powers/regenfield.json
@@ -116,6 +116,15 @@
             "comment": "//You can edit this 'hud_render' as you please."
         }
     },
+    "reset":{
+        "type": "origins:action_on_callback",
+        "entity_action_gained":{
+            "type": "origins:change_resource",
+            "resource": "justsap:regenfield_timer",
+            "change": 200,
+            "operation": "set"
+        }
+    },
     "trigger": {
         "type": "origins:active_self",
         "entity_action": {
@@ -136,7 +145,7 @@
                 },
                 {
                     "type": "origins:add_xp",
-                    "levels": -4
+                    "levels": -2
                 },
                 {
                     "type": "origins:play_sound",
@@ -176,7 +185,7 @@
                 {
                     "type": "origins:xp_levels",
                     "comparison": ">=",
-                    "compare_to": 4
+                    "compare_to": 2
                 }
             ]
         },

--- a/pack.mcmeta
+++ b/pack.mcmeta
@@ -4,7 +4,7 @@
         "id": "SaplingOrigin",
         "pack_format": 18,
         "authors": "JustSap",
-        "version": "1.0.0",
-        "description": "a weird plant themed origin by JustSap"
+        "version": "1.0.1",
+        "description": "a plant themed origin by JustSap"
     }
 }


### PR DESCRIPTION
# Changelog
- Fixed Bug with Nutrient Share ability where it would activate upon loading or spawning in world for the first time
- Reduced Nutrient Share ability EXP requirement & usage from 4 EXP levels to 2 EXP levels
- Increased Grounded Roots ability EXP requirement & usage from 2 EXP to 4 EXP

## Minor Changes
- Updated power descriptions that were changed
- Updated pack.mcmeta